### PR TITLE
More informative reporting

### DIFF
--- a/templates/codeowners.html.erb
+++ b/templates/codeowners.html.erb
@@ -9,9 +9,10 @@ review requests for the parts of the codebase that a PR changes.</p>
 most common issues we see are malformed owner assignments and incomplete
 coverage.  The owners assignment should be <code>@puppetlabs/&lt;team name&gt;</code>.
 We prefer team assignments, but you can also use an individual assignment if
-needed. To ensure complete code coverage, we recommend that you place a wildcard
-match (such as <code>* @puppetlabs/community-maintainers</code>) as your
-first rule in the <code>CODEOWNERS</code> file.
+needed as long as you make sure to keep it current. To ensure complete code
+coverage, we recommend that you place a wildcard match
+(such as <code>* @puppetlabs/community-maintainers</code>) as your first rule in
+the <code>CODEOWNERS</code> file.
 
 <p>See <a href="https://confluence.puppetlabs.com/display/OSP/Decision+rationale+for+use+of+CODEOWNERS+files">Confluence for more info</a></p>
 
@@ -32,6 +33,9 @@ first rule in the <code>CODEOWNERS</code> file.
   <li><a href="<%= repo[:html_url] %>"><%= repo[:full_name] %></a>
     <ul>
       <li><%= repo[:description] %></li>
+<% repo[:codeowner_errors].each do |error| -%>
+      <li><%= error %></li>
+<% end -%>
     </ul>
   </li>
 <% end %>
@@ -43,6 +47,18 @@ first rule in the <code>CODEOWNERS</code> file.
   <li><a href="<%= repo[:html_url] %>"><%= repo[:full_name] %></a>
     <ul>
       <li><%= repo[:description] %></li>
+    </ul>
+  </li>
+<% end %>
+</ul>
+
+<h3>Public repos with codepaths owned by users:</h3>
+<ul>
+<% userowned.each do |repo| -%>
+  <li><a href="<%= repo[:html_url] %>"><%= repo[:full_name] %></a>
+    <ul>
+      <li><%= repo[:description] %></li>
+      <li>Users: <%= repo[:codeowner_users].join(', ') %></li>
     </ul>
   </li>
 <% end %>

--- a/templates/codeowners.txt.erb
+++ b/templates/codeowners.txt.erb
@@ -8,10 +8,10 @@ parts of the codebase that a PR changes.
 This report helps to keep these files current, maintained, and correct. The most
 common issues we see are malformed owner assignments and incomplete coverage.
 The owners assignment should be '@puppetlabs/<team name>'. We prefer team
-assignments, but you can also use an individual assignment if needed. To ensure
-complete code coverage, we recommend that you place a wildcard match
-(such as '* @puppetlabs/community-maintainers') as your first rule in the
-CODEOWNERS file.
+assignments, but you can also use an individual assignment if needed as long as
+you make sure to keep it current. To ensure complete code coverage, we recommend
+that you place a wildcard match (such as '* @puppetlabs/community-maintainers')
+as your first rule in the CODEOWNERS file.
 
 See Confluence for more info:
   https://confluence.puppetlabs.com/display/OSP/Decision+rationale+for+use+of+CODEOWNERS+files
@@ -28,6 +28,9 @@ Public repos with malformed CODEOWNERS:
 <% malformed.each do |repo| -%>
 * <%= repo[:html_url] %>
     * <%= repo[:description] %>
+<% repo[:codeowner_errors].each do |error| -%>
+    * <%= error %>
+<% end -%>
 <% end -%>
 
 Public repos with incomplete codepath coverage:
@@ -35,6 +38,14 @@ Public repos with incomplete codepath coverage:
 <% coverage.each do |repo| -%>
 * <%= repo[:html_url] %>
     * <%= repo[:description] %>
+<% end -%>
+
+Public repos with codepaths owned by users:
+-----------------------------------------------
+<% userowned.each do |repo| -%>
+* <%= repo[:html_url] %>
+    * <%= repo[:description] %>
+    * Users: <%= repo[:codeowner_users].join(', ') %>
 <% end -%>
 
 -----------------------------------------------


### PR DESCRIPTION
This now includes a list of any offenses in the status report. It will
flag on teams that don't exist in our org and rules that don't match any
teams. It will also list users assigned in the CODEOWNERS files so that
people can keep track of users who've moved on.