### PR TITLE
Updates to the CloudCI reporting

### DIFF
--- a/.github/workflows/cloud_ci.yml
+++ b/.github/workflows/cloud_ci.yml
@@ -23,5 +23,5 @@ jobs:
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
-        bundle exec rake support_pulls
+        bundle exec rake cloud_ci
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 ---
 :org: puppetlabs
 :support_team: support
+:modules_team: modules
 :smtp:
   :from: 'Puppet Community Team <community@puppet.com>'
   :domain: 'puppet.com'

--- a/templates/cloud_ci.html.erb
+++ b/templates/cloud_ci.html.erb
@@ -1,7 +1,7 @@
 <p>Hi there!</p>
 
-<p>This is a quick report of all the puppetlabs repositories using the  CloudCI
-release workflow. We use it to keep track of our userbase, in part so that
+<p>This is a quick report of all the non-IAC puppetlabs module repositories using the
+CloudCI release workflow. We use it to keep track of our userbase, in part so that
 we can update and audit the list of repositories with access to the org-wide
 FORGE_API_KEY GitHub secret.</p>
 

--- a/templates/cloud_ci.txt.erb
+++ b/templates/cloud_ci.txt.erb
@@ -1,7 +1,7 @@
 Hi there!
 
-This is a quick report of all the puppetlabs repositories using the  CloudCI
-release workflow. We use it to keep track of our userbase, in part so that
+This is a quick report of all the non-IAC puppetlabs module repositories using the
+CloudCI release workflow. We use it to keep track of our userbase, in part so that
 we can update and audit the list of repositories with access to the org-wide
 FORGE_API_KEY GitHub secret.
 


### PR DESCRIPTION
This will now only report on module repositories that are not owned by the IAC team. (those are tracked separately)