### PR TITLE
Add report to check for missing licenses in public repos

### DIFF
--- a/.github/workflows/weekly-workflow.yml
+++ b/.github/workflows/weekly-workflow.yml
@@ -24,3 +24,4 @@ jobs:
         bundle install --jobs 4 --retry 3
         bundle exec rake stale_pulls
         bundle exec rake codeowner_coverage
+        bundle exec rake missing_licenses

--- a/README.md
+++ b/README.md
@@ -92,3 +92,9 @@ escalated privileges of the `EXTENDED_TOKEN` token. Owned/requested by:
 
 The email content is configured by [html](https://github.com/puppetlabs/repo_housekeeper/blob/main/templates/cloud_ci.html.erb) and [text](https://github.com/puppetlabs/repo_housekeeper/blob/main/templates/cloud_ci.txt.erb)
 format templates.
+
+### `missing_licenses`
+
+This task finds all public repositories that don't have an explicit license associated with them. It locates a license by the presence of a file in the root of the repository with a name that starts with "license", case insensitive.
+
+The email content is configured by [html](templates/missing_licenses.html.erb) and [text](templates/missing_licenses.txt.erb) format templates.

--- a/templates/missing_licenses.html.erb
+++ b/templates/missing_licenses.html.erb
@@ -1,0 +1,22 @@
+<p>Hello!</p>
+
+<p>This report contains a list of all public repositories that do not have an
+associated <code>LICENSE</code> file. To reduce confusion for our customers and
+community, all publicly accessible repos should have a license.</p>
+
+<h3>Public repositories that do not have a LICENSE file:</h3>
+<ul>
+<% missing.each do |repo| -%>
+  <li><a href="<%= repo[:html_url] %>"><%= repo[:full_name] %></a>
+    <ul>
+      <li><%= repo[:description] %></li>
+    </ul>
+  </li>
+<% end %>
+</ul>
+
+<hr />
+<p>
+  -- The Community Team<br />
+  If you've got feedback on this content, please let us know at <a href="mailto:community@puppet.com">community@puppet.com</a>.
+</p>

--- a/templates/missing_licenses.txt.erb
+++ b/templates/missing_licenses.txt.erb
@@ -1,0 +1,16 @@
+Hello!
+
+This report contains a list of all public repositories that do not have an
+associated <code>LICENSE</code> file. To reduce confusion for our customers and
+community, all publicly accessible repos should have a license.
+
+Public repositories that do not have a LICENSE file:
+----------------------------------------------------
+<% missing.each do |repo| -%>
+* <%= repo[:html_url] %>
+    * <%= repo[:description] %>
+<% end -%>
+
+-----------------------------------------------
+-- The Community Team
+If you've got feedback on this content, please let us know at community@puppet.com


### PR DESCRIPTION
Here, we add a report that will let us know which public repos don't currently have any file that looks like a license associated with them. I spot checked the results and they look accurate to me.

By the way, you could probably also get an appreciable performance increase in the `CODEOWNERS` check by not using a paginating client for retrieving the list of commits since we only need the very first one. In my test this took the time to work with very large repos (like puppetlabs/puppet) from minutes to a second or so.