### PR TITLE
(maint) Remove `sanity check`

### DIFF
--- a/templates/stale_prs.html.erb
+++ b/templates/stale_prs.html.erb
@@ -5,7 +5,7 @@ It would really help a ton if you'd help us out and clean up what you can. It's
 easier than you think:</p>
 
 <ol>
-  <li>First, just do a sanity check; is the repository even maintained anymore?
+  <li>First, check to see if the repository is even maintained anymore.
     Can it just be archived or deleted? See these <a
     href="https://confluence.puppetlabs.com/display/OSP/End+of+Maintenance+proposal">end-of-life
     suggestions</a>.</li>

--- a/templates/stale_prs.txt.erb
+++ b/templates/stale_prs.txt.erb
@@ -4,7 +4,7 @@ Following is a sample of some GitHub pull requests that could use some love. It
 would really help a ton if you'd help us out and clean up what you can. It's
 easier than you think:
 
-First, just do a sanity check; is the repository even maintained anymore? Can
+First, check to see if the repository is even maintained anymore. Can
 it just be archived or deleted? See the end-of-life suggestions below:
     * https://confluence.puppetlabs.com/display/OSP/End+of+Maintenance+proposal
 


### PR DESCRIPTION
This commit removes the use of `sanity check` from the Stale PRs templates.
This terminology is ableist and should be avoided.